### PR TITLE
feat(s3): add support for POST with UUID bucket postfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 AWS Sink is a `traefik` plugin that enable us to define a route to put data in S3 or dynamodb (not yet implemented) when `traefik` is deployed in ECS.
 
+## HTTP Verb Methods
+Use the `PUT` verb if you want to put an exact filename. 
+`POST` will append a [ULID](https://github.com/ulid/spec) to the path.  
+
 ### Example configuration
 
 `traefik.yml`

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/yoeluk/aws-sink
 
 go 1.20
+
+require (
+	github.com/oklog/ulid/v2 v2.1.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/local/local.go
+++ b/local/local.go
@@ -2,11 +2,13 @@ package local
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/oklog/ulid/v2"
 	"github.com/yoeluk/aws-sink/aws"
 	"github.com/yoeluk/aws-sink/log"
 	"github.com/yoeluk/aws-sink/signer"
-	"net/http"
-	"os"
 )
 
 type Sink struct {
@@ -42,4 +44,8 @@ func (s *Sink) Put(name string, payload []byte, contentType string, rw http.Resp
 	}
 	log.Debug(fmt.Sprintf("put %q object in %q local directory.", name, s.localDirectory))
 	return []byte(fmt.Sprintf("object %q was put in the local sink", name)), nil
+}
+
+func (s *Sink) Post(path string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error) {
+	return s.Put(path+"/"+ulid.Make().String(), payload, contentType, rw)
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/yoeluk/aws-sink/aws"
-	"github.com/yoeluk/aws-sink/log"
-	"github.com/yoeluk/aws-sink/signer"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/yoeluk/aws-sink/aws"
+	"github.com/yoeluk/aws-sink/log"
+	"github.com/yoeluk/aws-sink/signer"
 )
 
 type Sink struct {
@@ -64,6 +66,10 @@ func (s *Sink) Put(name string, payload []byte, contentType string, rw http.Resp
 	}
 	copyHeader(rw.Header(), resp.Header)
 	return response, nil
+}
+
+func (s *Sink) Post(path string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error) {
+	return s.Put(path+"/"+ulid.Make().String(), payload, contentType, rw)
 }
 
 func copyHeader(dst, src http.Header) {


### PR DESCRIPTION
Updated: I cleaned things up a bit. Not sure how to test/confirm.
Probably two approaches possible:
1) make it configurable
2) use verbs

This change is an initial sketch of the latter - if the verb is PUT it'll send it as per before. If it's a POST it'll add a UUID (ULID - a lexographically sorted variant) to the end. Collision should be unlikely but it's not using mac or anything specific to the host. We can probably prefix with the sp instance name for our use case. 

PUT = `$prefix/$name`
POST = `$prefix/$path/$UUID`

Lmk what you think.