### PR TITLE
fix(s3): change bucket postfix to use UUID instead of ULID

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AWS Sink is a `traefik` plugin that enable us to define a route to put data in S
 
 ## HTTP Verb Methods
 Use the `PUT` verb if you want to put an exact filename. 
-`POST` will append a [ULID](https://github.com/ulid/spec) to the path.  
+`POST` will append a UUID to the path.  
 
 ### Example configuration
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/yoeluk/aws-sink
 
 go 1.20
 
-require (
-	github.com/oklog/ulid/v2 v2.1.0 // indirect
-)
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,2 @@
-github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
-github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/local/local.go
+++ b/local/local.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/oklog/ulid/v2"
+	"github.com/google/uuid"
 	"github.com/yoeluk/aws-sink/aws"
 	"github.com/yoeluk/aws-sink/log"
 	"github.com/yoeluk/aws-sink/signer"
@@ -47,5 +47,5 @@ func (s *Sink) Put(name string, payload []byte, contentType string, rw http.Resp
 }
 
 func (s *Sink) Post(path string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error) {
-	return s.Put(path+"/"+ulid.Make().String(), payload, contentType, rw)
+	return s.Put(path+"/"+uuid.NewString(), payload, contentType, rw)
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/oklog/ulid/v2"
+	"github.com/google/uuid"
 	"github.com/yoeluk/aws-sink/aws"
 	"github.com/yoeluk/aws-sink/log"
 	"github.com/yoeluk/aws-sink/signer"
@@ -69,7 +69,7 @@ func (s *Sink) Put(name string, payload []byte, contentType string, rw http.Resp
 }
 
 func (s *Sink) Post(path string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error) {
-	return s.Put(path+"/"+ulid.Make().String(), payload, contentType, rw)
+	return s.Put(path+"/"+uuid.NewString(), payload, contentType, rw)
 }
 
 func copyHeader(dst, src http.Header) {


### PR DESCRIPTION
There was an issue w/ the pipeline related to ULID. I gave the idea of using them a shake and there is a higher chance of collision so I think it's a better idea to just use v4 UUIDs.

This change moves to the google uuid implementation for the postfix.